### PR TITLE
fix: soon to be broken link

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -25,7 +25,7 @@ Requirements
 ############
 
 1. SQLite library, built for your machine and operating system (SQLite prerequisite)
-2. https://github.com/tami5/sqlite.lua
+2. https://github.com/kkharji/sqlite.lua
 
 Setup
 #####


### PR DESCRIPTION
Hello @cpkio,

I recently changed my Github handle and realized I must keep existing references up to date, in order to prevent breaking your setup or, worse, exposing you to a security risk as a result of someone taking over my old handle and creating a repo with the same name.

Now, sqlite.lua link is updated.

